### PR TITLE
Replace ERB templating in README

### DIFF
--- a/templates/gem/README.md.tpl
+++ b/templates/gem/README.md.tpl
@@ -3,21 +3,15 @@
 [rubygem]: https://rubygems.org/gems/{{ .name.gem }}
 [actions]: https://github.com/{{ .github_org }}/{{ .name.gem }}/actions
 
-# <%= name %> [![Gem Version](https://badge.fury.io/rb/{{ .name.gem }}.svg)][rubygem] [![CI Status](https://github.com/{{ .github_org }}/{{ .name.gem }}/workflows/CI/badge.svg)][actions]
+# {{ .name.gem }} [![Gem Version](https://badge.fury.io/rb/{{ .name.gem }}.svg)][rubygem] [![CI Status](https://github.com/{{ .github_org }}/{{ .name.gem }}/workflows/CI/badge.svg)][actions]
 
-{{ if eq .github_org "dry-rb" -}}
 ## Links
 
-- [User documentation](https://<%= org %>.org/gems/<%= name %>)
-- [API documentation](http://rubydoc.info/gems/<%= name %>)
+- [User documentation]({{ .gemspec.homepage }})
+- [API documentation](http://rubydoc.info/gems/{{ .name.gem }})
+{{ if eq .github_org "dry-rb" -}}
 - [Forum](https://discourse.dry-rb.org)
 {{- end }}
-
-## Supported Ruby versions
-
-This library officially supports the following Ruby versions:
-
-- MRI >= 3.1
 
 ## License
 


### PR DESCRIPTION
Looks like this never got updated to use `tpl` instead of ERB.