### PR TITLE
Require minimum Ruby version of 3.2

### DIFF
--- a/templates/gem/.github/workflows/ci.yml.tpl
+++ b/templates/gem/.github/workflows/ci.yml.tpl
@@ -1,6 +1,6 @@
 # This file is synced from hanakai-rb/repo-sync
 
-{{ $ruby_versions := concat (list "3.4" "3.3" "3.2" "3.1") (.ci.rubies | default (list)) }}
+{{ $ruby_versions := concat (list "3.4" "3.3" "3.2") (.ci.rubies | default (list)) }}
 name: CI
 
 on:

--- a/templates/gem/gemspec.rb.tpl
+++ b/templates/gem/gemspec.rb.tpl
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.metadata["bug_tracker_uri"]   = "https://github.com/{{ $github_path }}/issues"
   spec.metadata["funding_uri"]       = "https://github.com/sponsors/hanami"
 
-  spec.required_ruby_version = "{{ default "3.1" .gemspec.required_ruby_version }}"
+  spec.required_ruby_version = "{{ default "3.2" .gemspec.required_ruby_version }}"
 {{ range default (list) .gemspec.runtime_dependencies }}
   spec.add_runtime_dependency "{{ join "\", \"" . }}"{{ end -}}
   {{ range default (list) .gemspec.development_dependencies }}


### PR DESCRIPTION
We support the current 3 versions, so Ruby 3.1 support is now EOL for us.