### PR TITLE
Fix required_ruby_version handling

### DIFF
--- a/templates/gem/gemspec.rb.tpl
+++ b/templates/gem/gemspec.rb.tpl
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.metadata["bug_tracker_uri"]   = "https://github.com/{{ $github_path }}/issues"
   spec.metadata["funding_uri"]       = "https://github.com/sponsors/hanami"
 
-  spec.required_ruby_version = "{{ default "3.2" .gemspec.required_ruby_version }}"
+  spec.required_ruby_version = "{{ default ">= 3.2" .gemspec.required_ruby_version }}"
 {{ range default (list) .gemspec.runtime_dependencies }}
   spec.add_runtime_dependency "{{ join "\", \"" . }}"{{ end -}}
   {{ range default (list) .gemspec.development_dependencies }}

--- a/templates/repo-sync-schema.json
+++ b/templates/repo-sync-schema.json
@@ -35,7 +35,7 @@
     },
     "gemspec": {
       "type": "object",
-      "required": ["authors", "email", "summary", "homepage", "required_ruby_version"],
+      "required": ["authors", "email", "summary", "homepage"],
       "properties": {
         "authors": {
           "type": "array",


### PR DESCRIPTION
Mark this as an optional value in each repo’s own repo-sync.yml.

Include the comparison operator in the default value, so that we produce properly working gemspecs when the repo-sync does not specify its own value (which should be our standard posture).