### PR TITLE
Run CI when version tags are pushed

### DIFF
--- a/templates/gem/.github/workflows/ci.yml.tpl
+++ b/templates/gem/.github/workflows/ci.yml.tpl
@@ -6,6 +6,7 @@ name: CI
 on:
   push:
     branches: ["main"]
+    tags: ["v*"]
   pull_request:
     branches: ["main"]
   schedule:


### PR DESCRIPTION
This is necessary for the dry-rb automated release process.