### PR TITLE
Fix the condition required to run the release job

### DIFF
--- a/templates/gem/.github/workflows/ci.yml.tpl
+++ b/templates/gem/.github/workflows/ci.yml.tpl
@@ -49,7 +49,7 @@ jobs:
       - uses: liskin/gh-workflow-keepalive@v1
   release:
     runs-on: ubuntu-latest
-    if: contains(github.ref, 'tags') && github.event_name == 'create'
+    if: github.ref_type == 'tag'
     needs: tests
     env:
       GITHUB_LOGIN: dry-bot


### PR DESCRIPTION
This condition works with the `on: push: tags: ["v*"]` trigger we now use for tag pushes (added in #60).