### PR TITLE
Remove byebug from standard development gems

### DIFF
--- a/templates/gem/Gemfile.devtools
+++ b/templates/gem/Gemfile.devtools
@@ -14,5 +14,4 @@ end
 
 group :tools do
   gem "rubocop", "~> 1.72.0"
-  gem "byebug"
 end


### PR DESCRIPTION
We have better alternatives to byebug now, like modern versions of irb. byebug also does not support JRuby, which we plan to activate in CI soon.