### PR TITLE
Run tests on JRuby in CI, allowing failures

### DIFF
--- a/templates/gem/.github/workflows/ci.yml.tpl
+++ b/templates/gem/.github/workflows/ci.yml.tpl
@@ -14,8 +14,11 @@ on:
 
 jobs:
   tests:
+    name: Tests ({{ print "${{" }} matrix.ruby }})
+    permissions:
+      pull-requests: write
     runs-on: ubuntu-latest
-    name: Tests
+    continue-on-error: {{ print "${{" }} matrix.optional }}
     strategy:
       fail-fast: false
       matrix:
@@ -23,9 +26,12 @@ jobs:
         {{ range $ruby_versions -}}
         - "{{ . }}"
         {{ end -}}
+        optional: [false]
         include:
           - ruby: "3.4"
             coverage: "true"
+          - ruby: "jruby"
+            optional: true
     env:
       COVERAGE: {{ print "${{" }}matrix.coverage}}
     steps:
@@ -39,7 +45,26 @@ jobs:
           ruby-version: {{ print "${{" }}matrix.ruby}}
           bundler-cache: true
       - name: Run all tests
-        run: bundle exec rake
+        id: test
+        run: |
+          status=0
+          bundle exec rake || status=$?
+          if [ ${status} -ne 0 ] && [ "{{ print "${{" }} matrix.optional }}" == "true" ]; then
+            echo "::warning::Optional matrix job failed."
+            echo "optional_fail=true" >> "${GITHUB_OUTPUT}"
+            echo "optional_fail_status=${status}" >> "${GITHUB_OUTPUT}"
+            exit 0  # Ignore error here to keep the green checkmark
+          fi
+          exit ${status}
+      - name: Add comment for optional failures
+        uses: thollander/actions-comment-pull-request@v3
+        if: {{ print "${{" }} matrix.optional && github.event.pull_request }}
+        with:
+          comment-tag: "{{ print "${{" }} matrix.ruby }}-optional-failure-notice"
+          message: |
+            ℹ️ Optional job failed: Ruby {{ print "${{" }} matrix.ruby }}
+          mode: {{ print "${{" }} steps.test.outputs.optional_fail == 'true' && 'upsert' || 'delete' }}
+
   workflow-keepalive:
     if: github.event_name == 'schedule'
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add JRuby to our CI matrix, but allow those tests to fail for now. This will help us identify which gems need some work before we can make it required for JRuby to pass.

Since GitHub Actions does not provide a built-in "allow failure" config for a step (see this [enormous feedback thread](https://github.com/actions/runner/issues/2347)), we have to cobble together our own equivalent functionality. This follows [an approach](https://github.com/actions/runner/issues/2347#issuecomment-2450473887) I found within the thead, which swallows any failure exit codes inside matrix jobs marked as "optional", and to surface the failure instead, it puts a comment on the PR.

I think this is a pretty decent workaround given this is intended to be temporary only until we get JRuby green. It _is_ quite important we keep green builds, since we need CI to release new versions of our gems.

I've generated a version of this ci.yml locally and pushed it up to ensure that it works. See https://github.com/dry-rb/dry-core/pull/86. Incidentally, dry-core is happy on JRuby, so I added an intentionally failing-on-jruby spec to ensure everything is still green.