### PR TITLE
Use latest rubocop across Dry gems

### DIFF
--- a/templates/gem/Gemfile.devtools
+++ b/templates/gem/Gemfile.devtools
@@ -13,5 +13,5 @@ group :test do
 end
 
 group :tools do
-  gem "rubocop", "~> 1.72.0"
+  gem "rubocop"
 end


### PR DESCRIPTION
We’re using cop names in our default RuboCop config that are not available in the previously specified version (see 659b0af and this corresponding [test failure](https://github.com/dry-rb/dry-system/actions/runs/19805918708)). Instead, just default to the latest version available.