### PR TITLE
Guard against focused specs in repos

### DIFF
--- a/templates/gem/spec/support/rspec.rb
+++ b/templates/gem/spec/support/rspec.rb
@@ -17,4 +17,12 @@ RSpec.configure do |config|
   config.define_derived_metadata do |meta|
     meta[:aggregate_failures] = true
   end
+
+  if ENV['CI']
+    # No focused specs should be committed. This ensures
+    # builds fail when this happens.
+    config.before(:each, :focus) do
+      raise StandardError, "You've committed a focused spec!"
+    end
+  end
 end


### PR DESCRIPTION
Focusing specs is handy locally, but when committed, it forces CI to run only those focused specs. This change makes sure CI builds fail when a focus spec is committed.