### PR TITLE
Enable ObjectSpace when testing with JRuby

### DIFF
--- a/templates/gem/.github/workflows/ci.yml.tpl
+++ b/templates/gem/.github/workflows/ci.yml.tpl
@@ -19,6 +19,8 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     continue-on-error: {{ print "${{" }} matrix.optional }}
+    env:
+      JRUBY_OPTS: ${{ matrix.jruby_opts || '' }}
     strategy:
       fail-fast: false
       matrix:
@@ -32,6 +34,7 @@ jobs:
             coverage: "true"
           - ruby: "jruby"
             optional: true
+            jruby_opts: "-X+O"
     env:
       COVERAGE: {{ print "${{" }}matrix.coverage}}
     steps:


### PR DESCRIPTION
Tests for dry-system require ObjectSpace enabled. With JRuby, we need to pass a specific options to do so. See: https://github.com/jruby/jruby/wiki/PerformanceTuning/cb0c89768de07287a5e3270fae0fbfd411e3c0a1#disabling-objectspace

I hope this works. @timriley do we have a way to test it before merging?