### PR TITLE
Add Ruby 4.0.0-preview2 to CI matrix, as optional

### DIFF
--- a/templates/gem/.github/workflows/ci.yml.tpl
+++ b/templates/gem/.github/workflows/ci.yml.tpl
@@ -32,6 +32,8 @@ jobs:
             coverage: "true"
           - ruby: "jruby"
             optional: true
+          - ruby: "4.0.0-preview2"
+            optional: true
     env:
       COVERAGE: {{ print "${{" }}matrix.coverage}}
     steps:


### PR DESCRIPTION
I think once we get 4.0 passing on all our repos (which will be released in 3 weeks), and we move 4.0 to the non-optional matrix, we should consider adding ["ruby-head"](https://github.com/ruby/setup-ruby) as an allowed failure. That might be a bit noisy though.