### PR TITLE
Replace tpl tool with (more capable) gomplate

### DIFF
--- a/local-sync/Dockerfile
+++ b/local-sync/Dockerfile
@@ -10,9 +10,9 @@ RUN curl -fsSL https://github.com/neilpa/yajsv/releases/download/v1.4.1/yajsv.li
 RUN curl -fsSL https://github.com/mikefarah/yq/releases/download/v4.27.5/yq_linux_amd64 > /usr/local/bin/yq && \
   chmod 755 /usr/local/bin/yq
 
-# Install go-template-cli (the tpl command, for rendering templates)
-RUN curl -fsSL https://github.com/bluebrown/go-template-cli/releases/download/v0.3.2/tpl-linux-amd64-static > /usr/local/bin/tpl && \
-  chmod 755 /usr/local/bin/tpl
+# Install gomplate (for rendering templates)
+RUN curl -fsSL https://github.com/hairyhenderson/gomplate/releases/download/v4.3.3/gomplate_linux-amd64 > /usr/local/bin/gomplate && \
+  chmod 755 /usr/local/bin/gomplate
 
 # Install bash, for our scripts
 RUN apk add --no-cache bash

--- a/repo-sync-action/Dockerfile
+++ b/repo-sync-action/Dockerfile
@@ -21,9 +21,9 @@ RUN curl -fsSL https://github.com/neilpa/yajsv/releases/download/v1.4.1/yajsv.li
 RUN curl -fsSL https://github.com/mikefarah/yq/releases/download/v4.27.5/yq_linux_amd64 > /usr/local/bin/yq && \
   chmod 755 /usr/local/bin/yq
 
-# Install go-template-cli (the tpl command, for rendering templates)
-RUN curl -fsSL https://github.com/bluebrown/go-template-cli/releases/download/v0.3.2/tpl-linux-amd64-static > /usr/local/bin/tpl && \
-  chmod 755 /usr/local/bin/tpl
+# Install gomplate (for rendering templates)
+RUN curl -fsSL https://github.com/hairyhenderson/gomplate/releases/download/v4.3.3/gomplate_linux-amd64 > /usr/local/bin/gomplate && \
+  chmod 755 /usr/local/bin/gomplate
 
 COPY functions.sh /functions.sh
 COPY entrypoint.sh /entrypoint.sh

--- a/repo-sync-action/functions.sh
+++ b/repo-sync-action/functions.sh
@@ -100,7 +100,7 @@ generate_target_filename() {
   local TEMP_FILE=$(mktemp)
   echo "$FILENAME" > "$TEMP_FILE"
 
-  tpl --file "$TEMP_FILE" --decoder yaml < "$REPO_SYNC_YML" > "${TEMP_FILE}.out" || {
+  gomplate --missing-key=zero -f "$TEMP_FILE" -c .="$REPO_SYNC_YML" > "${TEMP_FILE}.out" || {
     # If we can't generate the name, skip handling this file
     log "ERROR: Template processing failed for filename [$FILENAME]"
     rm "$TEMP_FILE" "${TEMP_FILE}.out" 2>/dev/null
@@ -145,10 +145,13 @@ generate_target_file() {
   fi
 
   # Process the template
-  tpl --file "$SOURCE_FULL_PATH" --decoder yaml < "$REPO_SYNC_YML" > "$DEST_FULL_PATH" || {
+  gomplate --missing-key=zero -f "$SOURCE_FULL_PATH" -c .="$REPO_SYNC_YML" > "$DEST_FULL_PATH" || {
     log "ERROR: Processing template ${SOURCE_FULL_PATH} failed"
     return 1
   }
+
+  # Add a newline to the end of template-generated files (gomplate strips trailing newlines)
+  echo >> "$DEST_FULL_PATH"
 }
 
 log() {

--- a/templates/gem/.github/workflows/ci.yml.tpl
+++ b/templates/gem/.github/workflows/ci.yml.tpl
@@ -1,6 +1,11 @@
 # This file is synced from hanakai-rb/repo-sync
 
-{{ $ruby_versions := concat (list "3.4" "3.3" "3.2") (.ci.rubies | default (list)) }}
+{{ $ruby_versions := coll.Slice "3.4" "3.3" "3.2" -}}
+{{ if and .ci .ci.rubies -}}
+  {{ range .ci.rubies -}}
+    {{ $ruby_versions = $ruby_versions | coll.Append . -}}
+  {{ end -}}
+{{ end -}}
 name: CI
 
 on:


### PR DESCRIPTION
[Gomplate](https://gomplate.ca) comes with a much richer function library and is _way_ more widely used (3.1k GitHub stars vs 37 for [tpl](https://github.com/bluebrown/go-template-cli)).

What I want from Gomplate in particular is the ability to conditionally include a file, like this:

```
{{ if file.Exists "README.gem.md" }}
{{ file.Read "README.gem.md" }}
{{ end }}
```

As you can see, this will unlock our ability to have a standard template README.md while still allowing for per-gem customisation of its main content area.