### PR TITLE
Run CI against more branches

### DIFF
--- a/templates/gem/.github/workflows/ci.yml.tpl
+++ b/templates/gem/.github/workflows/ci.yml.tpl
@@ -5,10 +5,10 @@ name: CI
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "release-*", "ci/*"]
     tags: ["v*"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "release-*"]
   schedule:
     - cron: "30 4 * * *"
 


### PR DESCRIPTION
For synced repos, run CI on:

1. Pushes to `release-*` branches (our long-lived branches for patch releases to previous releases)
2. Pull requests targeting release branches
3. Pushes to `ci/*` branches (a special case for branches where we want to run CI, but don’t want to create a full PR)

First two points are obvious and important cases for triggering builds.

The last one will be useful not only for work being done directly in those projects where you want to try a CI run minus a PR, but also for a feature I'd like to introduce to this repo-sync project, where a created PR will run its sync against a new branch in every synced repo, which I'll prefix with `ci/`. That way we can see the full impact of a sync, both on the repos _and_ their CI builds, before we merge.