### PR TITLE
Post PR comments via separate workflow

### DIFF
--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -47,6 +47,7 @@ jobs:
         templates/gem/.github/ISSUE_TEMPLATE/config.yml=.github/ISSUE_TEMPLATE/config.yml
         templates/gem/.github/SUPPORT.md=.github/SUPPORT.md
         templates/gem/.github/workflows/ci.yml.tpl=.github/workflows/ci.yml
+        templates/gem/.github/workflows/pr-comments.yml=.github/workflows/pr-comments.yml
         templates/gem/.github/workflows/rubocop.yml=.github/workflows/rubocop.yml
         templates/gem/.github/workflows/repo-sync-preview.yml=.github/workflows/repo-sync-preview.yml
         templates/gem/.rspec=.rspec
@@ -71,6 +72,7 @@ jobs:
         hanami/hanami
       files: |
         templates/gem/.github/workflows/ci.yml.tpl=.github/workflows/ci.yml
+        templates/gem/.github/workflows/pr-comments.yml=.github/workflows/pr-comments.yml
         templates/gem/.github/workflows/repo-sync-preview.yml=.github/workflows/repo-sync-preview.yml
         templates/gem/.github/FUNDING.yml=.github/FUNDING.yml
         templates/gem/.github/SUPPORT.md=.github/SUPPORT.md

--- a/pr-comment-artifact/action.yml
+++ b/pr-comment-artifact/action.yml
@@ -1,0 +1,41 @@
+name: Create PR comment artifact
+description: Creates an artifact to post a PR comment via the centralized post-pr-comments workflow.
+
+inputs:
+  name:
+    description: Name for the artifact (will be prefixed with "pr-comment-")
+    required: true
+  pr-number:
+    description: The pull request number
+    required: true
+  message:
+    description: The comment message body
+    required: true
+  comment-tag:
+    description: Unique tag for upserting/deleting comments
+    required: true
+  mode:
+    description: Either "upsert" or "delete"
+    required: false
+    default: upsert
+
+runs:
+  using: composite
+  steps:
+    - name: Prepare comment artifact
+      shell: bash
+      run: |
+        echo "${{ inputs.pr-number }}" > pr-number.txt
+        echo "${{ inputs.comment-tag }}" > comment-tag.txt
+        echo "${{ inputs.mode }}" > mode.txt
+        echo "${{ inputs.message }}" > message.txt
+
+    - name: Upload comment artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: pr-comment-${{ inputs.name }}
+        path: |
+          pr-number.txt
+          comment-tag.txt
+          mode.txt
+          message.txt

--- a/pr-comments-from-artifacts/action.yml
+++ b/pr-comments-from-artifacts/action.yml
@@ -1,0 +1,89 @@
+# Posts PR comments from artifacts created by completed workflows.
+#
+# This action is designed to work with the workflow_run trigger, allowing workflows that run with
+# read-only permissions (e.g., on fork PRs) to queue comments via artifacts, which are then posted
+# by a privileged workflow running in the base repo context.
+#
+# Expected artifact structure:
+#
+#   - Artifacts must be named "pr-comment-*"
+#   - Each artifact must contain:
+#     - pr-number.txt: The PR number (required)
+#     - message.txt: The comment body (required)
+#     - comment-tag.txt: Unique tag for upserting/deleting comments (optional)
+#     - mode.txt: Either "upsert" (default) or "delete" (optional)
+
+name: Post PR comments from artifacts
+description: Downloads comment artifacts from a workflow run and posts them to pull requests.
+
+inputs:
+  workflow-run-id:
+    description: The workflow run ID to download artifacts from
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Download artifacts and post comments
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const fs = require("fs");
+          const path = require("path");
+          const {owner, repo} = context.repo;
+
+          const readFile = (p) => {
+            return fs.existsSync(p) ? fs.readFileSync(p, "utf8").trim() : null;
+          };
+
+          const findComment = (comments, tag) => {
+            return comments.find(c => c.body?.includes(`<!-- pr-comment-tag: ${tag} -->`));
+          };
+
+          // Download and extract artifacts
+          const {data: {artifacts}} = await github.rest.actions.listWorkflowRunArtifacts({
+            owner, repo, run_id: ${{ inputs.workflow-run-id }},
+          });
+
+          const commentsDir = "pr-comments";
+          fs.mkdirSync(commentsDir, {recursive: true});
+
+          for (const artifact of artifacts.filter(a => a.name.startsWith("pr-comment-"))) {
+            const {data} = await github.rest.actions.downloadArtifact({
+              owner, repo, artifact_id: artifact.id, archive_format: "zip",
+            });
+            const zipPath = path.join(commentsDir, `${artifact.name}.zip`);
+            fs.writeFileSync(zipPath, Buffer.from(data));
+            const extractDir = path.join(commentsDir, artifact.name);
+            fs.mkdirSync(extractDir, {recursive: true});
+            await exec.exec("unzip", ["-q", zipPath, "-d", extractDir]);
+          }
+
+          // Process comments
+          const dirs = fs.readdirSync(commentsDir, {withFileTypes: true})
+            .filter(d => d.isDirectory()).map(d => d.name);
+
+          for (const dir of dirs) {
+            const base = path.join(commentsDir, dir);
+            const prNumber = parseInt(readFile(path.join(base, "pr-number.txt")));
+            const message = readFile(path.join(base, "message.txt"));
+
+            if (!prNumber || !message) continue;
+
+            const tag = readFile(path.join(base, "comment-tag.txt"));
+            const mode = readFile(path.join(base, "mode.txt")) || "upsert";
+
+            const {data: comments} = await github.rest.issues.listComments({owner, repo, issue_number: prNumber});
+            const existing = tag ? findComment(comments, tag) : null;
+
+            if (mode === "delete" && existing) {
+              await github.rest.issues.deleteComment({owner, repo, comment_id: existing.id});
+            } else {
+              const body = tag ? `<!-- pr-comment-tag: ${tag} -->\n${message}` : message;
+              if (existing) {
+                await github.rest.issues.updateComment({owner, repo, comment_id: existing.id, body});
+              } else {
+                await github.rest.issues.createComment({owner, repo, issue_number: prNumber, body});
+              }
+            }
+          }

--- a/templates/gem/.github/workflows/ci.yml.tpl
+++ b/templates/gem/.github/workflows/ci.yml.tpl
@@ -32,8 +32,6 @@ on:
 jobs:
   tests:
     name: Tests (Ruby {{ print "${{" }} matrix.ruby }}{{ if $has_matrix }}{{ range $key, $values := $matrix_dimensions }}, {{ strings.Title $key }} {{ print "${{" }} matrix.{{ $key }} }}{{ end }}{{ end }})
-    permissions:
-      pull-requests: write
     runs-on: ubuntu-latest
     continue-on-error: {{ print "${{" }} matrix.optional || false }}
     strategy:
@@ -130,13 +128,14 @@ jobs:
           {{ strings.ToUpper $key }}_MATRIX_VALUE: {{ print "${{" }} matrix.{{ $key }} || '' }}
           {{- end }}
         {{- end }}
-      - name: Add comment for optional failures
-        uses: thollander/actions-comment-pull-request@v3
+      - name: Create optional failure comment
         if: {{ print "${{" }} matrix.optional && github.event.pull_request }}
+        uses: hanakai-rb/repo-sync/pr-comment-artifact@main
         with:
-          comment-tag: "{{ print "${{" }} matrix.ruby }}-optional-failure-notice"
-          message: |
-            ℹ️ Optional job failed: Ruby {{ print "${{" }} matrix.ruby }}
+          name: ci-ruby-{{ print "${{" }} matrix.ruby }}
+          pr-number: {{ print "${{" }} github.event.pull_request.number }}
+          comment-tag: ruby-{{ print "${{" }} matrix.ruby }}-optional-failure
+          message: "ℹ️ Optional job failed: Ruby {{ print "${{" }} matrix.ruby }}"
           mode: {{ print "${{" }} steps.test.outputs.optional_fail == 'true' && 'upsert' || 'delete' }}
 
   workflow-keepalive:

--- a/templates/gem/.github/workflows/pr-comments.yml
+++ b/templates/gem/.github/workflows/pr-comments.yml
@@ -1,0 +1,30 @@
+# This file is synced from hanakai-rb/repo-sync
+
+# Downloads comment artifacts from completed workflows and posts them to PRs. This allows source
+# workflows to run with read-only permissions on fork PRs while still posting comments via this
+# privileged workflow that runs in the base repo context.
+#
+# Comment artifacts should be generated using the `hanakai-rb/repo-sync/pr-comment-artifact@main`
+# action.
+
+name: PR comments
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+
+jobs:
+  post-comments:
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == "pull_request"
+
+    steps:
+      - name: Post comments
+        uses: hanakai-rb/repo-sync/pr-comments-from-artifacts@main
+        with:
+          workflow-run-id: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
This allows for comments to be posted even for PRs coming from untrusted users and forks, where our main workflows have a read-only `GITHUB_TOKEN`. 

One option for solving this would be for our main workflows to use `on: pull_request_target`, which provides a read-write `GITHUB_TOKEN`. This would allow the comments to post, but would mean greater security risk because the whole workflow would be running with those elevated permissions for code changes from an unknown party.

So instead we take a two-phased approach for posting comments:

1. The original workflows run with their standard read-only permissions for fork PRs. Instead of attempting to post PR comments directly, they generate artifacts representing those comments.
2. We then run a second workflow with the `on: workflow_run` trigger, which has full read-write access, and is separate from the untrusted code. This downloads all comment artifacts and posts comments from their data.

To ensure this approach is maintainable and the workflow YAML concise, provide this functionality via two reusable actions hosted within this repo: `pr-comment-artifact` and `pr-comments-from-artifacts`.

This is based on the approach outlined in https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/.