### PR TITLE
Require minimum Ruby version of 3.3

### DIFF
--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -1,7 +1,7 @@
 # Please keep config grouped and ordered alphabetically.
 
 AllCops:
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
   DisplayCopNames: true
   DisplayStyleGuide: true
   ExtraDetails: false

--- a/templates/gem/.github/workflows/ci.yml.tpl
+++ b/templates/gem/.github/workflows/ci.yml.tpl
@@ -1,6 +1,6 @@
 # This file is synced from hanakai-rb/repo-sync
 
-{{ $ruby_versions := coll.Slice "4.0" "3.4" "3.3" "3.2" -}}
+{{ $ruby_versions := coll.Slice "4.0" "3.4" "3.3" -}}
 {{ if and .ci .ci.rubies -}}
   {{ range .ci.rubies -}}
     {{ $ruby_versions = $ruby_versions | coll.Append . -}}

--- a/templates/gem/gemspec.rb.tpl
+++ b/templates/gem/gemspec.rb.tpl
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
   spec.metadata["bug_tracker_uri"]   = "https://github.com/{{ $github_path }}/issues"
   spec.metadata["funding_uri"]       = "https://github.com/sponsors/hanami"
 
-  spec.required_ruby_version = "{{ .gemspec.required_ruby_version | default ">= 3.2" }}"
+  spec.required_ruby_version = "{{ .gemspec.required_ruby_version | default ">= 3.3" }}"
 {{ range (.gemspec.runtime_dependencies | default (coll.Slice)) }}
   spec.add_runtime_dependency "{{ join . "\", \"" }}"
 {{- end }}


### PR DESCRIPTION
Once Ruby 3.2 goes EOL (on 2026-03-31, according to https://www.ruby-lang.org/en/downloads/branches/), we can merge this and drop support.