### PR TITLE
Set distinct name for release runs

### DIFF
--- a/templates/gem/.github/workflows/ci.yml.tpl
+++ b/templates/gem/.github/workflows/ci.yml.tpl
@@ -19,6 +19,7 @@
 {{ end -}}
 {{ $has_matrix := gt (len $matrix_dimensions) 0 -}}
 name: CI
+run-name: {{ print "${{" }} github.ref_type == 'tag' && format('Release {0}', github.ref_name) || 'CI' }}
 
 on:
   push:


### PR DESCRIPTION
This will allow us to more easily distinguish release runs from ordinary CI runs.