### PR TITLE
Detect whether to announce release from tag message

### DIFF
--- a/templates/gem/.github/workflows/ci.yml.tpl
+++ b/templates/gem/.github/workflows/ci.yml.tpl
@@ -161,20 +161,24 @@ jobs:
       - name: Trigger release workflow
         uses: actions/github-script@v7
         with:
-          github-token: {{ print "${{" }} secrets.RELEASE_MACHINE_WORKFLOW_DISPATCH_TOKEN }}
+          github-token: {{ print "${{" }} secrets.RELEASE_MACHINE_DISPATCH_TOKEN }}
           script: |
             const tag = context.ref.replace("refs/tags/", "");
             const repo = context.repo.owner + "/" + context.repo.repo;
+
+            const tagMessage = await github.rest.git.getTag({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_sha: context.sha
+            }).then(res => res.data.message).catch(() => "");
+            const announce = /(skip-announce|no-announce)/i.test(tagMessage) ? "false" : "true";
 
             await github.rest.actions.createWorkflowDispatch({
               owner: "hanakai-rb",
               repo: "release-machine",
               workflow_id: "release.yml",
               ref: "main",
-              inputs: {
-                repo: repo,
-                tag: tag
-              }
+              inputs: { repo, tag, announce }
             });
 
             const workflowUrl = "https://github.com/hanakai-rb/release-machine/actions/workflows/release.yml";


### PR DESCRIPTION
Include "no-announce" or "skip-announce" to skip the announcement. The announcements will proceed in all other cases.