### PR TITLE
Add CI option to determine JRuby support

### DIFF
--- a/templates/gem/.github/workflows/ci.yml.tpl
+++ b/templates/gem/.github/workflows/ci.yml.tpl
@@ -7,9 +7,17 @@
   {{ end -}}
 {{ end -}}
 {{ $default_ruby := index $ruby_versions 0 -}}
-{{ $optional_rubies := coll.Slice
-  "jruby"
--}}
+{{/* JRuby is required by default, optional only when ci.jruby is explicitly false */ -}}
+{{ $jruby_optional := false -}}
+{{ if and .ci (eq .ci.jruby false) -}}
+  {{ $jruby_optional = true -}}
+{{ end -}}
+{{ $optional_rubies := coll.Slice -}}
+{{ if $jruby_optional -}}
+  {{ $optional_rubies = $optional_rubies | coll.Append "jruby" -}}
+{{ else -}}
+  {{ $ruby_versions = $ruby_versions | coll.Append "jruby" -}}
+{{ end -}}
 {{/* Normalize ci.matrix into a dict so we can safely iterate over it later */ -}}
 {{ $matrix_dimensions := dict -}}
 {{ if and .ci .ci.matrix -}}

--- a/templates/repo-sync-schema.json
+++ b/templates/repo-sync-schema.json
@@ -48,6 +48,10 @@
         "node": {
           "type": "boolean",
           "description": "Enable Node.js setup steps"
+        },
+        "jruby": {
+          "type": "boolean",
+          "description": "Determines if this gem supports JRuby. Default: true"
         }
       }
     },


### PR DESCRIPTION
This allows to determine whether JRuby is supported or not in gem's `repo-sync.yml`. As we discussed @timriley this is `true` by default, so probably should not be merged before whe add `jruby: false` to the ones we know fail currently on JRuby.

Diff generated for dry-cli (JRuby supported) using `local-sync`:

```diff
diff --git a/.github/workflows/ci.yml b/.github/workflows/ci.yml
index 86d0134..993e35b 100644
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,10 @@ jobs:
           - "3.4"
           - "3.3"
           - "3.2"
+          - "jruby"
         include:
           - ruby: "4.0"
             coverage: "true"
-          - ruby: "jruby"
-            optional: true
     env:
       COVERAGE: ${{ matrix.coverage }}
     steps:
```