### PR TITLE
Use release-machine for all (synced) hanami gems

### DIFF
--- a/templates/gem/.github/workflows/ci.yml.tpl
+++ b/templates/gem/.github/workflows/ci.yml.tpl
@@ -19,10 +19,8 @@
 {{ end -}}
 {{ $has_matrix := gt (len $matrix_dimensions) 0 -}}
 {{/* Gems using the new release-machine workflow (aside from Dry gems, which use it by default) */ -}}
-{{ $release_machine_gems := coll.Slice
-  "hanami-cli"
--}}
-{{ $use_release_machine := or (has $release_machine_gems .name.gem) (eq .github_org "dry-rb") -}}
+{{ $release_machine_gems := coll.Slice -}}
+{{ $use_release_machine := or (has $release_machine_gems .name.gem) (eq .github_org "dry-rb") (eq .github_org "hanami") -}}
 name: CI
 run-name: {{ print "${{" }} github.ref_type == 'tag' && format('Release {0}', github.ref_name) || 'CI' }}
 


### PR DESCRIPTION
We’ve tested it with hanami-cli already, and there’s no reason to hold back from using it for each new hanami repo that we bring under repo-sync management.