### PR TITLE
Remove allowed_push_host from gemspec metadata

### DIFF
--- a/templates/gem/gemspec.rb.tpl
+++ b/templates/gem/gemspec.rb.tpl
@@ -30,7 +30,6 @@ Gem::Specification.new do |spec|
   spec.extra_rdoc_files = ["README.md", "CHANGELOG.md", "LICENSE"]
 
   {{ $github_path := printf "%s/%s" .github_org .name.gem -}}
-  spec.metadata["allowed_push_host"] = "https://rubygems.org"
   spec.metadata["changelog_uri"]     = "https://github.com/{{ $github_path }}/blob/main/CHANGELOG.md"
   spec.metadata["source_code_uri"]   = "https://github.com/{{ $github_path }}"
   spec.metadata["bug_tracker_uri"]   = "https://github.com/{{ $github_path }}/issues"


### PR DESCRIPTION
This will allow us to publish to gem.coop in addition to rubygems.org.

See https://github.com/hanakai-rb/release-machine/pull/7 for the change to publish to gem.coop.