### PR TITLE
Sync hanami-controller-stub

### DIFF
--- a/repo-sync.yml
+++ b/repo-sync.yml
@@ -55,6 +55,7 @@ hanami:
     - hanami/hanami-action
     - hanami/hanami-assets
     - hanami/hanami-cli
+    - hanami/hanami-controller-stub
     - hanami/hanami-db
     - hanami/hanami-mailer
     - hanami/hanami-reloader

--- a/templates/gem/README.md.tpl
+++ b/templates/gem/README.md.tpl
@@ -1,11 +1,12 @@
 <!--- This file is synced from hanakai-rb/repo-sync -->
 
-[actions]: https://github.com/{{ .github_org }}/{{ .name.gem }}/actions
+{{ $repo_name := .github_repo | default .name.gem -}}
+[actions]: https://github.com/{{ .github_org }}/{{ $repo_name }}/actions
 [chat]: https://discord.gg/naQApPAsZB
 [forum]: https://discourse.hanamirb.org
 [rubygem]: https://rubygems.org/gems/{{ .name.gem }}
 
-# {{ .name.title | default .name.gem }} [![Gem Version](https://badge.fury.io/rb/{{ .name.gem }}.svg)][rubygem] [![CI Status](https://github.com/{{ .github_org }}/{{ .name.gem }}/workflows/CI/badge.svg)][actions]
+# {{ .name.title | default .name.gem }} [![Gem Version](https://badge.fury.io/rb/{{ .name.gem }}.svg)][rubygem] [![CI Status](https://github.com/{{ .github_org }}/{{ $repo_name }}/workflows/CI/badge.svg)][actions]
 
 [![Forum](https://img.shields.io/badge/Forum-dc360f?logo=discourse&logoColor=white)][forum]
 [![Chat](https://img.shields.io/badge/Chat-717cf8?logo=discord&logoColor=white)][chat]

--- a/templates/repo-sync-schema.json
+++ b/templates/repo-sync-schema.json
@@ -25,6 +25,10 @@
       "type": "string",
       "description": "GitHub organization name"
     },
+    "github_repo": {
+      "type": "string",
+      "description": "GitHub repo name (.name.gem will be used if not given)"
+    },
     "ci": {
       "type": "object",
       "properties": {


### PR DESCRIPTION
Introduce a `github_repo` var to `repo-sync.yml` so we can account (in the README links and badges) for this having a different repo name than its gem name.