### PR TITLE
Bump setup-ruby

### DIFF
--- a/.github/workflows/rubocop-config-lint.yml
+++ b/.github/workflows/rubocop-config-lint.yml
@@ -34,7 +34,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Ruby
-        uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # zizmor: ignore[cache-poisoning]
+        uses: ruby/setup-ruby@0cb964fd540e0a24c900370abf38a33466142735 # zizmor: ignore[cache-poisoning]
         with:
           ruby-version: "3.3"
 

--- a/templates/gem/.github/workflows/ci.yml.tpl
+++ b/templates/gem/.github/workflows/ci.yml.tpl
@@ -126,7 +126,7 @@ jobs:
         run: npm install
       {{ end -}}
       - name: Set up Ruby
-        uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # zizmor: ignore[cache-poisoning]
+        uses: ruby/setup-ruby@0cb964fd540e0a24c900370abf38a33466142735 # zizmor: ignore[cache-poisoning]
         with:
           ruby-version: {{ print "${{" }} matrix.ruby }}
           bundler-cache: true

--- a/templates/gem/.github/workflows/rubocop.yml
+++ b/templates/gem/.github/workflows/rubocop.yml
@@ -26,7 +26,7 @@ jobs:
           persist-credentials: false
 
       - name: Set up Ruby 4.0
-        uses: ruby/setup-ruby@e65c17d16e57e481586a6a5a0282698790062f92 # zizmor: ignore[cache-poisoning]
+        uses: ruby/setup-ruby@0cb964fd540e0a24c900370abf38a33466142735 # zizmor: ignore[cache-poisoning]
         with:
           ruby-version: 4.0
           bundler-cache: true


### PR DESCRIPTION
This will run JRuby tests on 10.1

On a sidenote, perhaps we should communicate that 10.1 is the supported version (even though technically it works on 10.0.5). Perhaps we could also test on JRuby head in addition to stable branch.