### PR TITLE
Sync hanami-assets-js via new hanami-js repo group

### DIFF
--- a/.github/workflows/repo-sync-job.yml
+++ b/.github/workflows/repo-sync-job.yml
@@ -41,6 +41,14 @@ jobs:
           echo "files<<EOF" >> $GITHUB_OUTPUT
           echo "$FILES" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
+
+          # Extract schema for the specified group; required.
+          SCHEMA=$(yq eval ".${INPUTS_GROUP}.schema" "$CONFIG_FILE")
+          if [[ -z "$SCHEMA" || "$SCHEMA" == "null" ]]; then
+            echo "ERROR: Group '${INPUTS_GROUP}' has no schema declared in repo-sync.yml" >&2
+            exit 1
+          fi
+          echo "schema=$SCHEMA" >> $GITHUB_OUTPUT
         env:
           INPUTS_GROUP: ${{ inputs.group }}
       - name: Sync
@@ -51,7 +59,7 @@ jobs:
           PR_EVENT_TYPE: ${{ github.event.action }}
           REPOSITORIES: ${{ steps.config.outputs.repos }}
           FILES: ${{ steps.config.outputs.files }}
-          REPO_SYNC_SCHEMA_PATH: templates/repo-sync-schema.json
+          REPO_SYNC_SCHEMA_PATH: ${{ steps.config.outputs.schema }}
           TOKEN: ${{ secrets.REPO_SYNC_TOKEN }}
       - name: Comment
         if: github.event.pull_request.number

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -28,3 +28,12 @@ jobs:
     with:
       id: hanami
       group: hanami
+
+  sync_hanami_js:
+    permissions: *permissions
+    uses: ./.github/workflows/repo-sync-job.yml
+    secrets:
+      REPO_SYNC_TOKEN: ${{ secrets.REPO_SYNC_TOKEN }}
+    with:
+      id: hanami-js
+      group: hanami-js

--- a/bin/local-sync
+++ b/bin/local-sync
@@ -9,8 +9,8 @@ DOCKER_IMAGE="repo-sync-local"
 DOCKER_DIR="${REPO_SYNC_ROOT}/local-sync"
 DOCKER_REBUILD=false
 DOCKER_SHELL=false
-REPO_SYNC_SCHEMA_PATH="templates/repo-sync-schema.json"
-REPO_SYNC_ORG=""
+REPO_SYNC_SCHEMA_PATH=""
+REPO_SYNC_GROUP=""
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
@@ -19,16 +19,17 @@ while [[ $# -gt 0 ]]; do
       echo "Hanakai repo sync local testing tool"
       echo ""
       echo "USAGE:"
-      echo "    $(basename "$0") --org <ORG> [OPTIONS] <REPOSITORY_PATH>"
+      echo "    $(basename "$0") --group <GROUP> [OPTIONS] <REPOSITORY_PATH>"
       echo ""
       echo "ARGUMENTS:"
       echo "    <REPOSITORY_PATH>    Path to the target repository directory"
       echo ""
       echo "OPTIONS:"
       echo "    --schema <PATH>      Path to repo-sync schema JSON file"
-      echo "                         (default: templates/repo-sync-schema.json)"
-      echo "    --org <ORG>         Organization name: dry or hanami [REQUIRED]"
-      echo "                         (determines which job to use in workflow)"
+      echo "                         (default: looked up from repo-sync.yml for the group;"
+      echo "                         override only when developing or debugging a schema)"
+      echo "    --group <GROUP>      Group name: dry, hanami, or hanami-js [REQUIRED]"
+      echo "                         (selects the group from repo-sync.yml)"
       echo "    --rebuild            Force rebuild of Docker image"
       echo "    --shell              Enter interactive shell instead of running sync"
       echo "    -h, --help           Show this help message"
@@ -43,19 +44,19 @@ while [[ $# -gt 0 ]]; do
       echo ""
       echo "EXAMPLES:"
       echo "    # Basic sync to a local repository"
-      echo "    $(basename "$0") --org dry /path/to/target/repository"
+      echo "    $(basename "$0") --group dry /path/to/target/repository"
       echo ""
       echo "    # Rebuild Docker image and sync"
-      echo "    $(basename "$0") --rebuild --org hanami /path/to/target/repository"
+      echo "    $(basename "$0") --rebuild --group hanami /path/to/target/repository"
       echo ""
       echo "    # Enter interactive shell for debugging"
       echo "    $(basename "$0") --shell /path/to/target/repository"
       echo ""
-      echo "    # Use custom schema file"
-      echo "    $(basename "$0") --schema /path/to/schema.json --org dry /path/to/target/repository"
+      echo "    # Use custom schema file (overrides per-group default)"
+      echo "    $(basename "$0") --schema /path/to/schema.json --group dry /path/to/target/repository"
       echo ""
-      echo "    # Specify organization (dry or hanami)"
-      echo "    $(basename "$0") --org hanami /path/to/target/repository"
+      echo "    # Sync an npm package repo"
+      echo "    $(basename "$0") --group hanami-js /path/to/target/repository"
       exit 0
       ;;
     --schema)
@@ -67,9 +68,9 @@ while [[ $# -gt 0 ]]; do
       DOCKER_REBUILD=true
       shift
       ;;
-    --org)
+    --group)
       shift
-      REPO_SYNC_ORG="$1"
+      REPO_SYNC_GROUP="$1"
       shift
       ;;
     --shell)
@@ -82,7 +83,7 @@ while [[ $# -gt 0 ]]; do
         TARGET_REPO_DIR=$(realpath "$1")
       else
         echo "Error: Unexpected argument: $1"
-        echo "Usage: $0 [--rebuild] --schema path/to/schema.json --org dry|hanami path/to/repo"
+        echo "Usage: $0 --group dry|hanami|hanami-js [--rebuild] [--schema path/to/schema.json] path/to/repo"
         exit 1
       fi
       shift
@@ -90,26 +91,20 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if [ -z "${REPO_SYNC_ORG}" ]; then
-  echo "Error: No organization specified"
-  echo "Usage: $0 --org dry|hanami [--rebuild] --schema path/to/schema.json path/to/repo"
+if [ -z "${REPO_SYNC_GROUP}" ]; then
+  echo "Error: No group specified"
+  echo "Usage: $0 --group dry|hanami|hanami-js [--rebuild] [--schema path/to/schema.json] path/to/repo"
   exit 1
 fi
 
-if [ -z "${REPO_SYNC_SCHEMA_PATH+x}" ]; then
-  echo "Error: No schema specified"
-  echo "Usage: $0 [--rebuild] --schema path/to/schema.json --org dry|hanami path/to/repo"
-  exit 1
-fi
-
-if [ ! -f "$REPO_SYNC_SCHEMA_PATH" ]; then
+if [ -n "${REPO_SYNC_SCHEMA_PATH}" ] && [ ! -f "$REPO_SYNC_SCHEMA_PATH" ]; then
   echo "Error: repo-sync schema file not found: $REPO_SYNC_SCHEMA_PATH"
   exit 1
 fi
 
 if [ -z "${TARGET_REPO_DIR+x}" ]; then
   echo "Error: No target repository specified"
-  echo "Usage: $0 [--rebuild] --schema path/to/schema.json --org dry|hanami path/to/repo"
+  echo "Usage: $0 --group dry|hanami|hanami-js [--rebuild] [--schema path/to/schema.json] path/to/repo"
   exit 1
 fi
 
@@ -125,11 +120,17 @@ fi
 
 REPO_NAME=$(basename "$TARGET_REPO_DIR")
 
+# Convert workspace-relative schema path to container-absolute, when given.
+# When unset, the container will look up the per-group schema from repo-sync.yml.
+if [ -n "${REPO_SYNC_SCHEMA_PATH}" ]; then
+  REPO_SYNC_SCHEMA_PATH="/workspace/${REPO_SYNC_SCHEMA_PATH}"
+fi
+
 DOCKER_ARGS=(
   "--rm"
   "-v" "${REPO_SYNC_ROOT}:/workspace"
-  "-e" "REPO_SYNC_SCHEMA_PATH=/workspace/${REPO_SYNC_SCHEMA_PATH}"
-  "-e" "REPO_SYNC_ORG=${REPO_SYNC_ORG}"
+  "-e" "REPO_SYNC_SCHEMA_PATH=${REPO_SYNC_SCHEMA_PATH}"
+  "-e" "REPO_SYNC_GROUP=${REPO_SYNC_GROUP}"
   "-v" "${TARGET_REPO_DIR}:/repos/${REPO_NAME}"
 )
 

--- a/local-sync/entrypoint.sh
+++ b/local-sync/entrypoint.sh
@@ -10,6 +10,17 @@ CONFIG_FILE="${SOURCE_DIR}/repo-sync.yml"
 
 source "${SOURCE_DIR}/repo-sync-action/functions.sh"
 
+# If the schema path wasn't passed in explicitly, look it up from the group's
+# config in repo-sync.yml.
+if [[ -z "$REPO_SYNC_SCHEMA_PATH" ]]; then
+  SCHEMA_REL=$(yq eval ".${REPO_SYNC_GROUP}.schema" "$CONFIG_FILE")
+  if [[ -z "$SCHEMA_REL" || "$SCHEMA_REL" == "null" ]]; then
+    echo "ERROR: Group '${REPO_SYNC_GROUP}' has no schema declared in repo-sync.yml" >&2
+    exit 1
+  fi
+  REPO_SYNC_SCHEMA_PATH="${SOURCE_DIR}/${SCHEMA_REL}"
+fi
+
 # Validate repo-sync.yml
 set +e
 validation_result=$(validate_repo_sync_yml "$TARGET_DIR" "$REPO_SYNC_SCHEMA_PATH" 2>&1)
@@ -23,7 +34,7 @@ fi
 
 # Sync files
 # Extract files for the group and convert from [source, target] pairs to source=target format
-FILES=$(yq eval ".${REPO_SYNC_ORG}.files | map(.[0] + \"=\" + .[1]) | .[]" "$CONFIG_FILE")
+FILES=$(yq eval ".${REPO_SYNC_GROUP}.files | map(.[0] + \"=\" + .[1]) | .[]" "$CONFIG_FILE")
 
 while IFS= read -r file_mapping; do
   if [ -n "$file_mapping" ]; then

--- a/repo-sync.yml
+++ b/repo-sync.yml
@@ -2,6 +2,7 @@
 #
 # Defines groups of repositories and files to sync. See `.github/workflows/repo-sync.yml`.
 dry:
+  schema: templates/repo-sync-schema.json
   repos:
     - dry-rb/dry-auto_inject
     - dry-rb/dry-cli
@@ -49,7 +50,26 @@ dry:
     - [templates/gem/spec/support/warnings.rb, spec/support/warnings.rb]
     - [zizmor.yml, zizmor.yml]
 
+hanami-js:
+  schema: templates/repo-sync-schema-npm.json
+  repos:
+    - hanami/hanami-assets-js
+  files:
+    - [templates/gem/.github/FUNDING.yml, .github/FUNDING.yml]
+    - [templates/gem/.github/ISSUE_TEMPLATE/config.yml, .github/ISSUE_TEMPLATE/config.yml]
+    - [templates/gem/.github/SUPPORT.md, .github/SUPPORT.md]
+    - [templates/gem/.github/workflows/ci-lint.yml, .github/workflows/ci-lint.yml]
+    - [templates/gem/.github/workflows/pr-comments.yml, .github/workflows/pr-comments.yml]
+    - [templates/gem/.github/workflows/repo-sync-preview.yml, .github/workflows/repo-sync-preview.yml]
+    - [templates/gem/CODE_OF_CONDUCT.md, CODE_OF_CONDUCT.md]
+    - [templates/gem/LICENSE, LICENSE]
+    - [templates/npm/.github/ISSUE_TEMPLATE/bug-report.md, .github/ISSUE_TEMPLATE/bug-report.md]
+    - [templates/npm/CONTRIBUTING.md, CONTRIBUTING.md]
+    - [templates/npm/README.md.tpl, README.md]
+    - [zizmor.yml, zizmor.yml]
+
 hanami:
+  schema: templates/repo-sync-schema.json
   repos:
     - hanami/hanami
     - hanami/hanami-action

--- a/templates/npm/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/templates/npm/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,25 @@
+---
+name: "\U0001F41B Bug report"
+about: See CONTRIBUTING.md for more information
+title: ''
+labels: bug, help wanted
+assignees: ''
+
+---
+
+## Describe the bug
+
+A clear and concise description of what the bug is.
+
+## To Reproduce
+
+Provide detailed steps to reproduce, **an executable script would be best**.
+
+## Expected behavior
+
+A clear and concise description of what you expected to happen.
+
+## My environment
+
+- Node.js version: ...
+- OS: ...

--- a/templates/npm/CONTRIBUTING.md
+++ b/templates/npm/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Issue guidelines
+
+## Reporting bugs
+
+If you’ve found a bug, please report an issue and describe the expected behavior versus what actually happens. If the bug causes a crash, attach a full backtrace. If possible, a reproduction script showing the problem is highly appreciated.
+
+## Reporting feature requests
+
+Report a feature request **only after discussing it first on [our forum](https://discourse.hanamirb.org)** and having it accepted. Please provide a concise description of the feature.
+
+## Reporting questions, support requests, ideas, concerns etc.
+
+**Please don’t.** Use [our forum](https://discourse.hanamirb.org) instead.
+
+# Pull request guidelines
+
+A pull request will only be accepted if it addresses a specific issue that was reported previously, or fixes typos, mistakes in documentation etc.
+
+Other requirements:
+
+1. Do not open a pull request if you can't provide tests along with it. If you have problems writing tests, ask for help in the related issue.
+2. Follow the style conventions of the surrounding code.
+3. Add API documentation if it's a new feature.
+4. Update API documentation if it changes an existing feature.
+5. Bonus points for sending a PR which updates user documentation in our [site repository](https://github.com/hanakai-rb/site).
+
+# Asking for help
+
+If these guidelines aren't helpful, and you're stuck, please post a message on [our forum](https://discourse.hanamirb.org) or [find us in chat](https://discord.gg/KFCxDmk3JQ).

--- a/templates/npm/README.md.tpl
+++ b/templates/npm/README.md.tpl
@@ -1,0 +1,25 @@
+<!--- This file is synced from hanakai-rb/repo-sync -->
+
+{{ $repo_name := .github_repo | default .name.title -}}
+[actions]: https://github.com/{{ .github_org }}/{{ $repo_name }}/actions
+[chat]: https://discord.gg/naQApPAsZB
+[forum]: https://discourse.hanamirb.org
+[npm]: https://www.npmjs.com/package/{{ .name.package }}
+
+# {{ .name.title }} [![npm Version](https://img.shields.io/npm/v/{{ .name.package }}.svg)][npm] [![CI Status](https://github.com/{{ .github_org }}/{{ $repo_name }}/workflows/CI/badge.svg)][actions]
+
+[![Forum](https://img.shields.io/badge/Forum-dc360f?logo=discourse&logoColor=white)][forum]
+[![Chat](https://img.shields.io/badge/Chat-717cf8?logo=discord&logoColor=white)][chat]
+
+{{ if (file.Exists "README.repo.md") -}}
+{{ file.Read "README.repo.md" }}
+{{ end -}}
+{{ if .homepage -}}
+## Links
+
+- [User documentation]({{ .homepage }})
+
+{{ end -}}
+## License
+
+See `LICENSE` file.

--- a/templates/repo-sync-schema-npm.json
+++ b/templates/repo-sync-schema-npm.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "required": ["name", "github_org"],
+  "properties": {
+    "name": {
+      "type": "object",
+      "required": ["title", "package"],
+      "properties": {
+        "title": {
+          "type": "string",
+          "description": "Display name of the project (used in README headings)"
+        },
+        "package": {
+          "type": "string",
+          "description": "npm package name (used for npm version badge and link in README)"
+        }
+      }
+    },
+    "github_org": {
+      "type": "string",
+      "description": "GitHub organization name"
+    },
+    "github_repo": {
+      "type": "string",
+      "description": "GitHub repo name (defaults to name.title if not given)"
+    },
+    "homepage": {
+      "type": "string",
+      "format": "uri",
+      "description": "Project homepage URL (used in README Links section)"
+    }
+  }
+}


### PR DESCRIPTION
Sync `hanami/hanami-assets-js` (the only npm package in the Hanami stack) under a new `hanami-js` group.

To make this fit comfortably, generalise the schema setup so that groups declare their own repo-sync.yml schema files.

In `local-sync`, rename the `--org` flag to `--group` to better fit the new makeup of the repo groups. Lookup the group's schema from config so it doesn't need to be supplied manually.

Add a few new templates in `templates/npm/` that were required for the specific nature of the hanami-assets-js repo (i.e. our only non-Ruby Gem).