### PR TITLE
Populate gemspec metadata, rename files to additional_files

### DIFF
--- a/templates/gem/gemspec.rb.tpl
+++ b/templates/gem/gemspec.rb.tpl
@@ -1,6 +1,6 @@
 {{ $gem_path := .name.gem | strings.ReplaceAll "-" "/" -}}
 {{ $default_files := coll.Slice "CHANGELOG.md" "LICENSE" "README.md" (printf "%s.gemspec" .name.gem) "lib/**/*" -}}
-{{ $file_globs := $default_files }}{{ range (.gemspec.files | default (coll.Slice)) }}{{ $file_globs = $file_globs | coll.Append . }}{{ end -}}
+{{ $file_globs := $default_files }}{{ range (.gemspec.additional_files | default (coll.Slice)) }}{{ $file_globs = $file_globs | coll.Append . }}{{ end -}}
 
 # frozen_string_literal: true
 
@@ -34,7 +34,8 @@ Gem::Specification.new do |spec|
   spec.metadata["source_code_uri"]   = "https://github.com/{{ $github_path }}"
   spec.metadata["bug_tracker_uri"]   = "https://github.com/{{ $github_path }}/issues"
   spec.metadata["funding_uri"]       = "https://github.com/sponsors/hanami"
-
+{{ range $key, $value := (.gemspec.metadata | default (coll.Dict)) }}  spec.metadata["{{ $key }}"] = "{{ $value }}"
+{{ end }}
   spec.required_ruby_version = "{{ .gemspec.required_ruby_version | default ">= 3.3" }}"
 {{ range (.gemspec.runtime_dependencies | default (coll.Slice)) }}
   spec.add_runtime_dependency "{{ join . "\", \"" }}"

--- a/templates/repo-sync-schema.json
+++ b/templates/repo-sync-schema.json
@@ -117,12 +117,19 @@
           },
           "description": "Runtime dependencies"
         },
-        "files": {
+        "additional_files": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "Additional file patterns to include in the gem"
+          "description": "Additional file patterns to include in spec.files"
+        },
+        "metadata": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Additional gemspec metadata entries"
         }
       }
     }


### PR DESCRIPTION
Populate gemspec metadata from repo-sync.yml. And rename gemspec.files to gemspec.additional_files to make its purpose clearer.

This allows us to support the "default_lint_roller_plugin" metadata added to Dry AutoInject in https://github.com/dry-rb/dry-auto_inject/pull/96.