### PR TITLE
Enforce fixed indentation for ArgumentAlignment

### DIFF
--- a/rubocop/rubocop.yml
+++ b/rubocop/rubocop.yml
@@ -32,6 +32,9 @@ Lint/AmbiguousBlockAssociation:
   Exclude:
     - "spec/**/*.rb"
 
+Layout/ArgumentAlignment:
+  EnforcedStyle: with_fixed_indentation
+
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 


### PR DESCRIPTION
This is the only way to allow (IMO) sensible formatting for parens-less method calls, like this:

```ruby
  gem "activerecord-jdbcsqlite3-adapter",
    github: "jruby/activerecord-jdbc-adapter",
    ref: "74aeab07a97001de74591ff5f50a6ff9807e9faa",
    platform: :jruby
```

The default enforced style of `with_first_argument` otherwise results in large irregular chunks of whitespace due to needing to bump everything to the right to match the first arg.